### PR TITLE
Allow specifying multiple namespaces

### DIFF
--- a/downscale.go
+++ b/downscale.go
@@ -9,7 +9,8 @@ import (
 
 var downCmd = &cobra.Command{
 	Use:     "down",
-	Short:   "Downscale all deployments in a namespace",
+	Short:   "Downscale all deployments in the desired namespaces",
+	Example: "szero down -n default -n klum",
 	Aliases: []string{"downscale"},
 	Run: func(cmd *cobra.Command, args []string) {
 		clientset, err := getClientset(kubeconfig)
@@ -18,17 +19,19 @@ var downCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		deployments, err := getDeployments(ctx, clientset, namespace)
-		if err != nil {
-			log.Fatal(err)
-		}
+		for _, namespace := range namespaces {
+			deployments, err := getDeployments(ctx, clientset, namespace)
+			if err != nil {
+				log.Fatal(err)
+			}
 
-		log.Infof("Found %d deployments", len(deployments.Items))
-		downscaled, err := downscaleDeployments(ctx, clientset, deployments)
-		if err != nil {
-			log.Fatal(err)
+			log.Infof("Found %d deployments in namespace %s", len(deployments.Items), namespace)
+			downscaled, err := downscaleDeployments(ctx, clientset, deployments)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Infof("Downscaled %d deployments", downscaled)
 		}
-		log.Infof("Downscaled %d deployments", downscaled)
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var (
 	Date       = "unknown"
 	BuiltBy    = "dirty hands"
 	kubeconfig string
-	namespace  string
+	namespaces []string
 	rootCmd    = &cobra.Command{
 		Use:   "szero",
 		Short: "Completely downscale and upscale back deployments",
@@ -31,7 +31,7 @@ func getDefaultPath() string {
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "k", getDefaultPath(), "Path to kubeconfig file")
-	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "Kubernetes namespace")
+	rootCmd.PersistentFlags().StringSliceVarP(&namespaces, "namespace", "n", []string{"default"}, "Kubernetes namespace")
 
 	err := rootCmd.RegisterFlagCompletionFunc("namespace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		ctx := context.Background()

--- a/restart.go
+++ b/restart.go
@@ -8,8 +8,9 @@ import (
 )
 
 var restartCmd = &cobra.Command{
-	Use:   "restart",
-	Short: "Restart all deployments in a namespace",
+	Use:     "restart",
+	Short:   "Restart all deployments in the desired namespaces",
+	Example: "szero restart -n default -n klum",
 	Run: func(cmd *cobra.Command, args []string) {
 		clientset, err := getClientset(kubeconfig)
 		if err != nil {
@@ -17,17 +18,19 @@ var restartCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		deployments, err := getDeployments(ctx, clientset, namespace)
-		if err != nil {
-			log.Fatal(err)
-		}
+		for _, namespace := range namespaces {
+			deployments, err := getDeployments(ctx, clientset, namespace)
+			if err != nil {
+				log.Fatal(err)
+			}
 
-		log.Infof("Found %d deployments", len(deployments.Items))
-		downscaled, err := restartDeployments(ctx, clientset, deployments)
-		if err != nil {
-			log.Fatal(err)
+			log.Infof("Found %d deployments in namespace %s", len(deployments.Items), namespace)
+			downscaled, err := restartDeployments(ctx, clientset, deployments)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Infof("Downscaled %d deployments", downscaled)
 		}
-		log.Infof("Downscaled %d deployments", downscaled)
 	},
 }
 

--- a/upscale.go
+++ b/upscale.go
@@ -8,7 +8,8 @@ import (
 
 var upCmd = &cobra.Command{
 	Use:     "up",
-	Short:   "Upscale all deployments in a namespace to their original size",
+	Short:   "Upscale all deployments in the desired namespaces to their original size",
+	Example: "szero up -n default -n klum",
 	Aliases: []string{"upscale"},
 	Run: func(cmd *cobra.Command, args []string) {
 		clientset, err := getClientset(kubeconfig)
@@ -17,17 +18,19 @@ var upCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		deployments, err := getDeployments(ctx, clientset, namespace)
-		if err != nil {
-			log.Fatal(err)
-		}
+		for _, namespace := range namespaces {
+			deployments, err := getDeployments(ctx, clientset, namespace)
+			if err != nil {
+				log.Fatal(err)
+			}
 
-		log.Infof("Found %d deployments", len(deployments.Items))
-		upscaled, err := upscaleDeployments(ctx, clientset, deployments)
-		if err != nil {
-			log.Fatal(err)
+			log.Infof("Found %d deployments in namespace %s", len(deployments.Items), namespace)
+			upscaled, err := upscaleDeployments(ctx, clientset, deployments)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Infof("Upscaled %d deployments", upscaled)
 		}
-		log.Infof("Upscaled %d deployments", upscaled)
 	},
 }
 


### PR DESCRIPTION
This makes it easier when we need several namespaces to be downscaled/upscaled/restarted.
You can do it in list mode: `szero down -n default -n kafka -n elasticsearch`