### PR TITLE
Allow user to specify a context

### DIFF
--- a/contexts.go
+++ b/contexts.go
@@ -1,0 +1,31 @@
+package main
+
+import "k8s.io/client-go/tools/clientcmd"
+
+func getDefaultKubernetesContext(kubeconfig string) string {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: "",
+		}).RawConfig()
+	if err != nil {
+		return ""
+	}
+	return config.CurrentContext
+}
+
+func getContexts() ([]string, error) {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: "",
+		}).RawConfig()
+	if err != nil {
+		return nil, err
+	}
+	contexts := make([]string, 0, len(config.Contexts))
+	for key := range config.Contexts {
+		contexts = append(contexts, key)
+	}
+	return contexts, nil
+}

--- a/deployments.go
+++ b/deployments.go
@@ -18,8 +18,12 @@ const replicasAnnotation = "szero/replicas"
 const restartedAtAnnotation = "kubernetes.io/restartedAt"
 const changeCauseAnnotation = "kubernetes.io/change-cause"
 
-func getClientset(kubeconfig string) (*kubernetes.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+func getClientset(kubeconfig, context string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: context,
+		}).ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error building config: %w", err)
 	}

--- a/downscale.go
+++ b/downscale.go
@@ -13,7 +13,7 @@ var downCmd = &cobra.Command{
 	Example: "szero down -n default -n klum",
 	Aliases: []string{"downscale"},
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset, err := getClientset(kubeconfig)
+		clientset, err := getClientset(kubeconfig, kubecontext)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/restart.go
+++ b/restart.go
@@ -12,7 +12,7 @@ var restartCmd = &cobra.Command{
 	Short:   "Restart all deployments in the desired namespaces",
 	Example: "szero restart -n default -n klum",
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset, err := getClientset(kubeconfig)
+		clientset, err := getClientset(kubeconfig, kubecontext)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/upscale.go
+++ b/upscale.go
@@ -12,7 +12,7 @@ var upCmd = &cobra.Command{
 	Example: "szero up -n default -n klum",
 	Aliases: []string{"upscale"},
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset, err := getClientset(kubeconfig)
+		clientset, err := getClientset(kubeconfig, kubecontext)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Allow using a different context than the currently set for a config.
This way we don't need to manually switch contexts to do operations.
Example:
`szero down --kubeconfig=aws --context dev --namespace myservice`