### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/szero/security/code-scanning/3](https://github.com/jadolg/szero/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's code during the `actions/checkout` step.
- No additional permissions are required for the other steps, as they do not interact with GitHub resources.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
