### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: 0 19 * * 5
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/szero/security/code-scanning/2](https://github.com/jadolg/szero/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the `govulncheck` action to read the repository's code and perform its analysis. This change adheres to the principle of least privilege and ensures the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
