### PR TITLE
Add options to wait for the changes to be applied

### DIFF
--- a/cmd/szero/cmd_downscale.go
+++ b/cmd/szero/cmd_downscale.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"github.com/jadolg/szero/pkg"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -68,6 +67,10 @@ var downCmd = &cobra.Command{
 				}
 				log.Infof("Downscaled %d daemonsets", downscaleDaemonsets)
 			}
+		}
+
+		if wait {
+			waitForResourcesOrFatal(ctx, clientset, true)
 		}
 	},
 }

--- a/cmd/szero/cmd_upscale.go
+++ b/cmd/szero/cmd_upscale.go
@@ -68,6 +68,10 @@ var upCmd = &cobra.Command{
 				log.Infof("Upscaled %d daemonsets", upscaledDaemonsets)
 			}
 		}
+
+		if wait {
+			waitForResourcesOrFatal(ctx, clientset, false)
+		}
 	},
 }
 

--- a/cmd/szero/main.go
+++ b/cmd/szero/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"time"
+
 	"github.com/jadolg/szero/pkg"
 	"os"
 	"path/filepath"
@@ -24,6 +26,9 @@ var (
 	skipDaemonsets   bool
 	skipStatefulsets bool
 	skipDeployments  bool
+
+	wait    bool
+	timeout time.Duration
 
 	rootCmd = &cobra.Command{
 		Use:   "szero",
@@ -51,6 +56,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&skipDaemonsets, "skip-daemonsets", "d", false, "Skip daemonsets")
 	rootCmd.PersistentFlags().BoolVarP(&skipStatefulsets, "skip-statefulsets", "s", false, "Skip statefulsets")
 	rootCmd.PersistentFlags().BoolVarP(&skipDeployments, "skip-deployments", "p", false, "Skip deployments")
+
+	rootCmd.PersistentFlags().BoolVarP(&wait, "wait", "w", false, "Wait for all resources to reconcile into the desired state")
+	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 5*time.Minute, "Timeout for waiting for resources to reconcile into the desired state")
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	err := rootCmd.RegisterFlagCompletionFunc("namespace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/szero/wait.go
+++ b/cmd/szero/wait.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/jadolg/szero/pkg"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+)
+
+func waitForResourcesOrFatal(ctx context.Context, clientset kubernetes.Interface, downscaled bool) {
+	waitFor := len(namespaces) * 3 // deployments, statefulsets, and daemonsets per namespace
+	errors := make(chan error, 1)
+	done := make(chan bool, waitFor)
+
+	log.Infof("Waiting for all resources to reach the desired state in %d namespaces (timeout %v)", len(namespaces), timeout)
+
+	for _, namespace := range namespaces {
+		if !skipDeployments {
+			go func(errors chan error) {
+				waitForDeployments(ctx, clientset, namespace, downscaled, done, errors)
+			}(errors)
+		} else {
+			waitFor--
+		}
+
+		if !skipStatefulsets {
+			go func(errors chan error) {
+				waitForStatefulSets(ctx, clientset, namespace, downscaled, done, errors)
+			}(errors)
+		} else {
+			waitFor--
+		}
+
+		if !skipDaemonsets {
+			go func(errors chan error) {
+				waitForDaemonSets(ctx, clientset, namespace, downscaled, done, errors)
+			}(errors)
+		} else {
+			waitFor--
+		}
+	}
+
+	for {
+		select {
+		case err := <-errors:
+			if err != nil {
+				log.Fatalf("Error waiting for resources to reach desired state: %v", err)
+			}
+		case <-done:
+			waitFor--
+			if waitFor == 0 {
+				return
+			}
+		}
+	}
+}
+
+func waitForDaemonSets(ctx context.Context, clientset kubernetes.Interface, namespace string, downscaled bool, done chan bool, errors chan error) {
+	daemonsets, err := pkg.GetDaemonsets(ctx, clientset, namespace)
+	if err != nil {
+		errors <- err
+		return
+	}
+	err = pkg.WaitForDaemonSets(ctx, clientset, daemonsets, timeout, downscaled)
+	if err != nil {
+		errors <- fmt.Errorf("could not wait for DaemonSets in namespace %s: %w", namespace, err)
+		return
+	}
+	done <- true
+}
+
+func waitForStatefulSets(ctx context.Context, clientset kubernetes.Interface, namespace string, downscaled bool, done chan bool, errors chan error) {
+	statefulsets, err := pkg.GetStatefulSets(ctx, clientset, namespace)
+	if err != nil {
+		errors <- err
+		return
+	}
+	err = pkg.WaitForStatefulSets(ctx, clientset, statefulsets, timeout, downscaled)
+	if err != nil {
+		errors <- fmt.Errorf("could not wait for StatefulSets in namespace %s: %w", namespace, err)
+		return
+	}
+	done <- true
+}
+
+func waitForDeployments(ctx context.Context, clientset kubernetes.Interface, namespace string, downscaled bool, done chan bool, errors chan error) {
+	deployments, err := pkg.GetDeployments(ctx, clientset, namespace)
+	if err != nil {
+		errors <- err
+		return
+	}
+	err = pkg.WaitForDeployments(ctx, clientset, deployments, timeout, downscaled)
+	if err != nil {
+		errors <- fmt.Errorf("could not wait for Deployments in namespace %s: %w", namespace, err)
+		return
+	}
+	done <- true
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -18,14 +18,14 @@ assert "kubectl get deployment testdeployment001 -o jsonpath='{.spec.replicas}'"
 assert "kubectl get sts teststatefulset001 -o jsonpath='{.spec.replicas}'" "2"
 assert "kubectl get ds testdaemonset001 -o jsonpath='{.status.desiredNumberScheduled}'" "1"
 
-./szero down
+./szero down --wait
 
 assert "kubectl get deployment testdeployment001 -o jsonpath='{.spec.replicas}'" "0"
 assert "kubectl get sts teststatefulset001 -o jsonpath='{.spec.replicas}'" "0"
 assert "kubectl get ds testdaemonset001 -o jsonpath='{.status.desiredNumberScheduled}'" "0"
 assert_eventually "kubectl get pods --no-headers | wc -l" "0"
 
-./szero up
+./szero up --wait
 
 assert "kubectl get deployment testdeployment001 -o jsonpath='{.spec.replicas}'" "3"
 assert "kubectl get sts teststatefulset001 -o jsonpath='{.spec.replicas}'" "2"


### PR DESCRIPTION
This introduces the flags `--wait` and `--timeout`.

Now when doing for instance `szero down --wait` the application will block and wait for a maximum of the value specified in timeout.