### PR TITLE
chore: update Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jadolg/szero
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/charmbracelet/fang v1.0.0


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.2**.

### Changes
- go.mod: go 1.26.1 → go 1.26.2

_Automated PR by update-go-version.sh_